### PR TITLE
[MINOR] Fixed typo in myheaders.hbs

### DIFF
--- a/views/http/myheaders.hbs
+++ b/views/http/myheaders.hbs
@@ -1,7 +1,7 @@
 {{> above}}
 
 <div class="alert alert-info">
-    These are the HTTP headers that are being sent my your browser.
+    These are the HTTP headers that are being sent by your browser.
 </div>
 <table class="table table-striped">
     <thead>


### PR DESCRIPTION
Fixing a minor typo in `myheaders.hbs`

This was originally reported on HN: https://news.ycombinator.com/item?id=24889076